### PR TITLE
File size vs available space check

### DIFF
--- a/plugin.video.kodipopcorntime/resources/language/English/strings.xml
+++ b/plugin.video.kodipopcorntime/resources/language/English/strings.xml
@@ -164,6 +164,8 @@
   <string id="30319">xxxx</string>
   <string id="30320">xxxx</string>
   <string id="30321">xxxx</string>
+  <string id="30323">Not enough space in </string>
+
 
   <!-- 
    * Genres


### PR DESCRIPTION
Initial support.
To get the file size we need to start downloading file. Tested on Windows x64, but should support *nix/Mac OS.
TODO: clearup in case of space not enough, as for some reason torrent2http won't remove the files on its own