### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-#Where can I find a newer version?#
+# Where can I find a newer version? #
 
 * [Markop159](https://github.com/markop159) - [Download page](https://github.com/markop159/KODI-Popcorn-Time/wiki/Download) or [repository](https://github.com/markop159/Markop159-repository/tree/master/Releases/plugin.video.kodipopcorntime) - [Source](https://github.com/markop159/KODI-Popcorn-Time)
 * [Chaen](https://github.com/chaen) - [Download page](https://github.com/chaen/KODI-Popcorn-Time/releases) - [Source](https://github.com/chaen/KODI-Popcorn-Time/)
 
 <hr>
 
-##There will be no more updates##
+## There will be no more updates ##
 
 I'm sorry, but I do not have time to the project.
 
 <hr>
 
 [![Code Climate](https://codeclimate.com/github/Diblo/KODI-Popcorn-Time/badges/gpa.svg)](https://codeclimate.com/github/Diblo/KODI-Popcorn-Time)
-##KODI Popcorn Time##
+## KODI Popcorn Time ##
 
-###What it is###
+### What it is ###
 With KODI Popcorn Time you can search for movies that you can see immediately in KODI.
 
-###Download###
+### Download ###
 Check out the [releases](http://github.com/Diblo/KODI-Popcorn-Time/releases) tab to download the ZIP file.
 
-###Supported Platforms###
+### Supported Platforms ###
 * XBMC/KODI 13.x and later
 * Windows x32 and x64
 * OS X x32 and x64
@@ -28,27 +28,27 @@ Check out the [releases](http://github.com/Diblo/KODI-Popcorn-Time/releases) tab
 * Raspberry Pi
 * Android ARM 4.0+
 
-###Discussions/Proposals###
+### Discussions/Proposals ###
 There is one active threads on [tvaddons.ag](http://forums.tvaddons.ag/threads/32586-KODI-Popcorn-Time?p=271031). However, proposals may also be posted under [Issues](http://github.com/Diblo/KODI-Popcorn-Time/issues).
 
-###Issues###
+### Issues ###
 Please, file an issue :) - [Issues](http://github.com/Diblo/KODI-Popcorn-Time/issues)
 
-###Credits###
+### Credits ###
 * KODI Popcorn Time is a rewrite of [xbmctorrent](http://github.com/steeve/xbmctorrent).
 * http://github.com/steeve/libtorrent-go
 * http://github.com/steeve/torrent2http
 
-###Changelog###
+### Changelog ###
 Check out [releases](http://github.com/Diblo/KODI-Popcorn-Time/releases).
 
-###Need more information###
+### Need more information ###
 Check out our [WIKI page](http://github.com/Diblo/KODI-Popcorn-Time/wiki/Welcome-to-the-KODI-Popcorn-Time-wiki!)
 
-###Test releases###
+### Test releases ###
 http://github.com/Diblo/KODI-Popcorn-Time/wiki/Test-releases
 
-###HELP WANTED###
+### HELP WANTED ###
 Please, see our WIKI page [Help wanted](http://github.com/Diblo/KODI-Popcorn-Time/wiki/Help-wanted)
 
 Many thanks in advance.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
